### PR TITLE
perf: optmised the trackresponse data on show details of component

### DIFF
--- a/app/components/TrackComponent/index.js
+++ b/app/components/TrackComponent/index.js
@@ -120,7 +120,9 @@ export function TrackComponent({ trackData, isShowDetailsButton, isShowDetails, 
     handlePauseTrackWrapper(audioRef);
   };
 
-  const handleTrackDetailsRoute = trackId => history.push(`/tracks/${trackId}`);
+  const handleTrackDetailsRoute = trackId => {
+    history.push(`/tracks/${trackId}`);
+  };
 
   return (
     <TrackCardContainer data-testid="track-component">
@@ -171,7 +173,7 @@ export function TrackComponent({ trackData, isShowDetailsButton, isShowDetails, 
 
       <ButtonWrapper>
         <If condition={isShowDetailsButton}>
-          <ShowDetailsBtn onClick={() => handleTrackDetailsRoute(trackId)}>
+          <ShowDetailsBtn data-testid="showDetails" onClick={() => handleTrackDetailsRoute(trackId)}>
             <ButtonLabel> Show Details </ButtonLabel>
           </ShowDetailsBtn>
         </If>

--- a/app/components/TrackComponent/index.js
+++ b/app/components/TrackComponent/index.js
@@ -18,7 +18,7 @@ const { Paragraph } = Typography;
 const TrackCardContainer = styled(Card)`
   && {
     border-radius: 0.5rem;
-    width: ${props => (props.width ? props.width : '25rem')};
+    width: 25rem;
     border: 1px solid ${colors.secondary};
     text-align: center;
 `;

--- a/app/components/TrackComponent/tests/__snapshots__/index.test.js.snap
+++ b/app/components/TrackComponent/tests/__snapshots__/index.test.js.snap
@@ -4,7 +4,7 @@ exports[`<TrackComponent /> should render and match the snapshot 1`] = `
 <body>
   <div>
     <div
-      class="ant-card ant-card-bordered TrackComponent__TrackCardContainer-sc-1y7fh5t-0 hZfrIv"
+      class="ant-card ant-card-bordered TrackComponent__TrackCardContainer-sc-1y7fh5t-0 jBWOdU"
       data-testid="track-component"
     >
       <div

--- a/app/components/TrackComponent/tests/index.test.js
+++ b/app/components/TrackComponent/tests/index.test.js
@@ -46,19 +46,4 @@ describe('<TrackComponent />', () => {
     await timeout(500);
     expect(button).toHaveTextContent(/pause/i);
   });
-
-  it('should call the handlePlayPause on PlayTrackBtn when it is clicked', async () => {
-    const handlePlayPauseSpy = jest.fn();
-
-    const { queryByRole, queryByTestId } = renderProvider(
-      <TrackComponent trackData={MOCK_TRACK_DATA} handlePauseTrackWrapper={handlePauseTrackWrapperSpy} />
-    );
-    const audio = queryByTestId('trackAudio');
-    const button = queryByRole('button');
-
-    fireEvent.click(button, { onclick: handlePlayPauseSpy() });
-    await timeout(500);
-    expect(handlePlayPauseSpy).toBeCalled();
-    expect(handlePauseTrackWrapperSpy).toBeCalledWith({ current: audio });
-  });
 });

--- a/app/components/TrackComponent/tests/index.test.js
+++ b/app/components/TrackComponent/tests/index.test.js
@@ -46,4 +46,19 @@ describe('<TrackComponent />', () => {
     await timeout(500);
     expect(button).toHaveTextContent(/pause/i);
   });
+
+  it('should call the handlePlayPause on PlayTrackBtn when it is clicked', async () => {
+    const handlePlayPauseSpy = jest.fn();
+
+    const { queryByRole, queryByTestId } = renderProvider(
+      <TrackComponent trackData={MOCK_TRACK_DATA} handlePauseTrackWrapper={handlePauseTrackWrapperSpy} />
+    );
+    const audio = queryByTestId('trackAudio');
+    const button = queryByRole('button');
+
+    fireEvent.click(button, { onclick: handlePlayPauseSpy() });
+    await timeout(500);
+    expect(handlePlayPauseSpy).toBeCalled();
+    expect(handlePauseTrackWrapperSpy).toBeCalledWith({ current: audio });
+  });
 });

--- a/app/containers/TracksContainer/TrackDetailsContainer/index.js
+++ b/app/containers/TracksContainer/TrackDetailsContainer/index.js
@@ -38,7 +38,7 @@ export function TrackDetailsContainer({ dispatchRequestTrackDetails, trackDetail
 
   return (
     <Wrapper>
-      <If condition={!isEmpty(trackDetails)}>
+      <If condition={!isEmpty(trackDetails)} otherwise={`No track details available for track id: ${trackId}`}>
         <TrackDetailsWrapper>
           <TrackComponent trackData={trackDetails} isShowDetails={true} />
         </TrackDetailsWrapper>

--- a/app/containers/TracksContainer/TrackDetailsContainer/tests/__snapshots__/index.test.js.snap
+++ b/app/containers/TracksContainer/TrackDetailsContainer/tests/__snapshots__/index.test.js.snap
@@ -10,7 +10,7 @@ exports[`<TrackDetailsContainer /> container tests should render and match the s
         class="TrackDetailsContainer__TrackDetailsWrapper-tevgmx-1 jKPgDN"
       >
         <div
-          class="ant-card ant-card-bordered TrackComponent__TrackCardContainer-sc-1y7fh5t-0 hZfrIv"
+          class="ant-card ant-card-bordered TrackComponent__TrackCardContainer-sc-1y7fh5t-0 jBWOdU"
           data-testid="track-component"
         >
           <div

--- a/app/containers/TracksContainer/index.js
+++ b/app/containers/TracksContainer/index.js
@@ -2,7 +2,7 @@ import React, { memo, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Input, Card, Skeleton } from 'antd';
-import { debounce, get, isEmpty } from 'lodash';
+import { debounce, isEmpty } from 'lodash';
 import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import { injectSaga } from 'redux-injectors';
@@ -65,7 +65,7 @@ export function TracksContainer({
   const [currentPlayingTrack, setCurrentPlayingTrack] = useState(null);
 
   useEffect(() => {
-    if (trackName && !tracksData?.results?.length) {
+    if (trackName && !tracksData) {
       dispatchRequestTracksData(trackName);
     }
   }, []);
@@ -91,14 +91,12 @@ export function TracksContainer({
   const debouncedHandleOnChange = debounce(handleOnChange, 200);
 
   const renderTracksList = () => {
-    const loadedTrackSongs = get(tracksData, 'results', []);
-
     return (
-      <If condition={!isEmpty(loadedTrackSongs) || tracksLoading}>
+      <If condition={!isEmpty(tracksData) || tracksLoading}>
         <TitleCard>
           <Skeleton loading={tracksLoading} active>
             <For
-              of={loadedTrackSongs}
+              of={Object.values(tracksData)}
               ParentComponent={TrackGrid}
               renderItem={(item, index) => (
                 <TrackComponent
@@ -139,18 +137,16 @@ export function TracksContainer({
 TracksContainer.propTypes = {
   maxWidth: PropTypes.number,
   padding: PropTypes.number,
+  length: PropTypes.number,
+  tracksData: PropTypes.object,
   trackName: PropTypes.string,
   artistName: PropTypes.string,
-  trackData: PropTypes.object,
   dispatchRequestTracksData: PropTypes.func,
   dispatchRequestTrackDetails: PropTypes.func,
   dispatchClearTracksData: PropTypes.func,
   intl: PropTypes.object,
   tracksError: PropTypes.object,
-  tracksLoading: PropTypes.bool,
-  tracksData: PropTypes.shape({
-    results: PropTypes.array
-  })
+  tracksLoading: PropTypes.bool
 };
 
 TracksContainer.defaultProps = {

--- a/app/containers/TracksContainer/saga.js
+++ b/app/containers/TracksContainer/saga.js
@@ -11,7 +11,7 @@ export function* requestGetTracks(action) {
   const { data, ok } = res;
 
   const tracksDataResponse = data?.results;
-  const optimisedTrackData = tracksDataResponse?.reduce((obj, item) => ({ ...obj, [item.trackId]: { ...item } }), []);
+  const optimisedTrackData = tracksDataResponse?.reduce((obj, item) => ({ ...obj, [item.trackId]: { ...item } }), {});
   //check if ok
   if (ok) {
     yield put(successGetTracks(optimisedTrackData));

--- a/app/containers/TracksContainer/saga.js
+++ b/app/containers/TracksContainer/saga.js
@@ -10,9 +10,11 @@ export function* requestGetTracks(action) {
   const res = yield call(getSongs, action.trackName);
   const { data, ok } = res;
 
+  const tracksDataResponse = data?.results;
+  const optimisedTrackData = tracksDataResponse?.reduce((obj, item) => ({ ...obj, [item.trackId]: { ...item } }), []);
   //check if ok
   if (ok) {
-    yield put(successGetTracks(data));
+    yield put(successGetTracks(optimisedTrackData));
   } else {
     yield put(failureGetTracks(data));
   }
@@ -21,8 +23,7 @@ export function* requestGetTracks(action) {
 export function* requestGetTrackDetails(action) {
   const tracksData = yield select(selectTracksData());
 
-  let foundTrackItem = tracksData?.data?.results?.find(track => track?.trackId === action.trackId);
-
+  let foundTrackItem = tracksData[action.trackId];
   if (foundTrackItem) {
     yield put(successGetTrackDetails(foundTrackItem));
   } else {

--- a/app/containers/TracksContainer/saga.js
+++ b/app/containers/TracksContainer/saga.js
@@ -22,7 +22,6 @@ export function* requestGetTracks(action) {
 
 export function* requestGetTrackDetails(action) {
   const tracksData = yield select(selectTracksData());
-
   let foundTrackItem = tracksData[action.trackId];
   if (foundTrackItem) {
     yield put(successGetTrackDetails(foundTrackItem));

--- a/app/containers/TracksContainer/tests/__snapshots__/index.test.js.snap
+++ b/app/containers/TracksContainer/tests/__snapshots__/index.test.js.snap
@@ -159,6 +159,7 @@ exports[`TracksContainer Tests should render and match to the snapshot 1`] = `
               >
                 <button
                   class="TrackComponent__ShowDetailsBtn-sc-1y7fh5t-4 cxivdz"
+                  data-testid="showDetails"
                 >
                   <span
                     class="TrackComponent__ButtonLabel-sc-1y7fh5t-6 ftUulf"
@@ -247,6 +248,7 @@ exports[`TracksContainer Tests should render and match to the snapshot 1`] = `
               >
                 <button
                   class="TrackComponent__ShowDetailsBtn-sc-1y7fh5t-4 cxivdz"
+                  data-testid="showDetails"
                 >
                   <span
                     class="TrackComponent__ButtonLabel-sc-1y7fh5t-6 ftUulf"

--- a/app/containers/TracksContainer/tests/__snapshots__/index.test.js.snap
+++ b/app/containers/TracksContainer/tests/__snapshots__/index.test.js.snap
@@ -82,6 +82,196 @@ exports[`TracksContainer Tests should render and match to the snapshot 1`] = `
         </div>
       </div>
     </div>
+    <div
+      class="ant-card ant-card-bordered TracksContainer__TitleCard-jv1ui9-0 fTXtPF"
+    >
+      <div
+        class="ant-card-body"
+      >
+        <div
+          class="TracksContainer__TrackGrid-jv1ui9-3 gvaiGt"
+          data-testid="for"
+          orientation="row"
+        >
+          <div
+            class="ant-card ant-card-bordered TrackComponent__TrackCardContainer-sc-1y7fh5t-0 hZfrIv"
+            data-testid="track-component"
+          >
+            <div
+              class="ant-card-body"
+            >
+              <div
+                class="ant-image"
+              >
+                <img
+                  class="ant-image-img"
+                />
+                <div
+                  class="ant-image-mask"
+                >
+                  <div
+                    class="ant-image-mask-info"
+                  >
+                    <span
+                      aria-label="eye"
+                      class="anticon anticon-eye"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="eye"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M942.2 486.2C847.4 286.5 704.1 186 512 186c-192.2 0-335.4 100.5-430.2 300.3a60.3 60.3 0 000 51.5C176.6 737.5 319.9 838 512 838c192.2 0 335.4-100.5 430.2-300.3 7.7-16.2 7.7-35 0-51.5zM512 766c-161.3 0-279.4-81.8-362.7-254C232.6 339.8 350.7 258 512 258c161.3 0 279.4 81.8 362.7 254C791.5 684.2 673.4 766 512 766zm-4-430c-97.2 0-176 78.8-176 176s78.8 176 176 176 176-78.8 176-176-78.8-176-176-176zm0 288c-61.9 0-112-50.1-112-112s50.1-112 112-112 112 50.1 112 112-50.1 112-112 112z"
+                        />
+                      </svg>
+                    </span>
+                    Preview
+                  </div>
+                </div>
+              </div>
+              <div
+                class="TrackComponent__StyledDescription-sc-1y7fh5t-1 ehlPZI"
+              >
+                <div
+                  class="ant-typography"
+                >
+                  No artist name available
+                </div>
+                <div
+                  class="ant-typography"
+                >
+                  No collection name available
+                </div>
+                <div
+                  class="ant-typography"
+                >
+                  No track name available
+                </div>
+              </div>
+              <div
+                class="TrackComponent__ButtonWrapper-sc-1y7fh5t-5 dehKAG"
+              >
+                <button
+                  class="TrackComponent__ShowDetailsBtn-sc-1y7fh5t-4 cxivdz"
+                >
+                  <span
+                    class="TrackComponent__ButtonLabel-sc-1y7fh5t-6 ftUulf"
+                  >
+                     Show Details 
+                  </span>
+                </button>
+                <button
+                  class="TrackComponent__PlayTrackBtn-sc-1y7fh5t-3 khRFCr"
+                >
+                  <span
+                    class="TrackComponent__ButtonLabel-sc-1y7fh5t-6 ftUulf"
+                  >
+                     Play 
+                  </span>
+                </button>
+              </div>
+              <audio
+                data-testid="trackAudio"
+              />
+            </div>
+          </div>
+          <div
+            class="ant-card ant-card-bordered TrackComponent__TrackCardContainer-sc-1y7fh5t-0 hZfrIv"
+            data-testid="track-component"
+          >
+            <div
+              class="ant-card-body"
+            >
+              <div
+                class="ant-image"
+              >
+                <img
+                  class="ant-image-img"
+                />
+                <div
+                  class="ant-image-mask"
+                >
+                  <div
+                    class="ant-image-mask-info"
+                  >
+                    <span
+                      aria-label="eye"
+                      class="anticon anticon-eye"
+                      role="img"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        data-icon="eye"
+                        fill="currentColor"
+                        focusable="false"
+                        height="1em"
+                        viewBox="64 64 896 896"
+                        width="1em"
+                      >
+                        <path
+                          d="M942.2 486.2C847.4 286.5 704.1 186 512 186c-192.2 0-335.4 100.5-430.2 300.3a60.3 60.3 0 000 51.5C176.6 737.5 319.9 838 512 838c192.2 0 335.4-100.5 430.2-300.3 7.7-16.2 7.7-35 0-51.5zM512 766c-161.3 0-279.4-81.8-362.7-254C232.6 339.8 350.7 258 512 258c161.3 0 279.4 81.8 362.7 254C791.5 684.2 673.4 766 512 766zm-4-430c-97.2 0-176 78.8-176 176s78.8 176 176 176 176-78.8 176-176-78.8-176-176-176zm0 288c-61.9 0-112-50.1-112-112s50.1-112 112-112 112 50.1 112 112-50.1 112-112 112z"
+                        />
+                      </svg>
+                    </span>
+                    Preview
+                  </div>
+                </div>
+              </div>
+              <div
+                class="TrackComponent__StyledDescription-sc-1y7fh5t-1 ehlPZI"
+              >
+                <div
+                  class="ant-typography"
+                >
+                  No artist name available
+                </div>
+                <div
+                  class="ant-typography"
+                >
+                  No collection name available
+                </div>
+                <div
+                  class="ant-typography"
+                >
+                  No track name available
+                </div>
+              </div>
+              <div
+                class="TrackComponent__ButtonWrapper-sc-1y7fh5t-5 dehKAG"
+              >
+                <button
+                  class="TrackComponent__ShowDetailsBtn-sc-1y7fh5t-4 cxivdz"
+                >
+                  <span
+                    class="TrackComponent__ButtonLabel-sc-1y7fh5t-6 ftUulf"
+                  >
+                     Show Details 
+                  </span>
+                </button>
+                <button
+                  class="TrackComponent__PlayTrackBtn-sc-1y7fh5t-3 khRFCr"
+                >
+                  <span
+                    class="TrackComponent__ButtonLabel-sc-1y7fh5t-6 ftUulf"
+                  >
+                     Play 
+                  </span>
+                </button>
+              </div>
+              <audio
+                data-testid="trackAudio"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 </body>
 `;

--- a/app/containers/TracksContainer/tests/__snapshots__/index.test.js.snap
+++ b/app/containers/TracksContainer/tests/__snapshots__/index.test.js.snap
@@ -94,7 +94,7 @@ exports[`TracksContainer Tests should render and match to the snapshot 1`] = `
           orientation="row"
         >
           <div
-            class="ant-card ant-card-bordered TrackComponent__TrackCardContainer-sc-1y7fh5t-0 hZfrIv"
+            class="ant-card ant-card-bordered TrackComponent__TrackCardContainer-sc-1y7fh5t-0 jBWOdU"
             data-testid="track-component"
           >
             <div
@@ -182,7 +182,7 @@ exports[`TracksContainer Tests should render and match to the snapshot 1`] = `
             </div>
           </div>
           <div
-            class="ant-card ant-card-bordered TrackComponent__TrackCardContainer-sc-1y7fh5t-0 hZfrIv"
+            class="ant-card ant-card-bordered TrackComponent__TrackCardContainer-sc-1y7fh5t-0 jBWOdU"
             data-testid="track-component"
           >
             <div

--- a/app/containers/TracksContainer/tests/index.test.js
+++ b/app/containers/TracksContainer/tests/index.test.js
@@ -15,7 +15,10 @@ describe('TracksContainer Tests', () => {
   });
   it('should render and match to the snapshot', () => {
     const { baseElement } = renderWithIntl(
-      <TracksContainer dispatchRequestTracksData={mockdispatchRequestTracksData} />
+      <TracksContainer
+        dispatchRequestTracksData={mockdispatchRequestTracksData}
+        tracksData={{ 1: { name: 'song1' }, 2: { name: 'song1' } }}
+      />
     );
     expect(baseElement).toMatchSnapshot();
   });
@@ -23,7 +26,10 @@ describe('TracksContainer Tests', () => {
   // dispatch track names
   it('should call dispatchRequestTracksData on change', async () => {
     const { queryByTestId } = renderWithIntl(
-      <TracksContainer dispatchRequestTracksData={mockdispatchRequestTracksData} />
+      <TracksContainer
+        dispatchRequestTracksData={mockdispatchRequestTracksData}
+        tracksData={{ 1: { name: 'song1' }, 2: { name: 'song1' } }}
+      />
     );
     fireEvent.change(queryByTestId('search-bar'), {
       target: { value: 'Arijit' }
@@ -34,21 +40,9 @@ describe('TracksContainer Tests', () => {
 
   // testing For component
   it('should render For component when tracksData is available', async () => {
-    const data = {
-      resultCount: 2,
-      results: [
-        {
-          id: 1,
-          name: 'First data'
-        },
-        {
-          id: 2,
-          name: 'Second Data'
-        }
-      ]
-    };
+    let tracksDummyData = { 1: { name: 'song1' }, 2: { name: 'song1' } };
     await timeout(500);
-    const { queryByTestId } = renderProvider(<TracksContainer tracksData={data} />);
+    const { queryByTestId } = renderProvider(<TracksContainer tracksData={tracksDummyData} />);
     expect(queryByTestId('for')).toBeInTheDocument();
   });
 
@@ -57,7 +51,11 @@ describe('TracksContainer Tests', () => {
     let searchTrackNamesSpy = jest.fn();
     let clearTracksDataSpy = jest.fn();
     const { queryByTestId } = renderWithIntl(
-      <TracksContainer dispatchRequestTracksData={searchTrackNamesSpy} dispatchClearTracksData={clearTracksDataSpy} />
+      <TracksContainer
+        tracksData={{ 1: { name: 'song1' }, 2: { name: 'song1' } }}
+        dispatchRequestTracksData={searchTrackNamesSpy}
+        dispatchClearTracksData={clearTracksDataSpy}
+      />
     );
 
     fireEvent.change(queryByTestId('search-bar'), {

--- a/app/containers/TracksContainer/tests/saga.test.js
+++ b/app/containers/TracksContainer/tests/saga.test.js
@@ -12,7 +12,9 @@ import { apiResponseGenerator } from '@app/utils/testUtils';
 describe('TracksContainer saga tests', () => {
   const generator = tracksContainerSaga();
   let trackName = 'Arijit';
+  let trackId = 123456;
   let requestGetTracksGenerator = null;
+  let requestGetTrackDetailsGenerator = null;
 
   it('should start task to watch for REQUEST_GET_TRACKS', () => {
     expect(generator.next().value).toEqual(takeLatest(trackContainerTypes.REQUEST_GET_TRACKS, requestGetTracks));
@@ -64,21 +66,28 @@ describe('TracksContainer saga tests', () => {
     );
   });
 
-  // it('should ensure that the action SUCCESS_GET_TRACK_DETAILS is dispatched when the api call succeeds', () => {
-  //   requestGetTrackDetailsGenerator = requestGetTrackDetails({ trackId });
-  //   const dataObj = { 18556408: { name: 'song1', trackId: 18556408 } };
-  //   requestGetTrackDetailsGenerator.next(dataObj).value;
-  //   requestGetTrackDetailsGenerator.next(dataObj).value;
-  //   const data = { results: [{ trackId }] };
-  //   const dummyTrackDetailsObj = { name: 'song1', trackId: 18556408 };
-  //   console.log(requestGetTrackDetailsGenerator.next().value);
+  it('should ensure that the action SUCCESS_GET_TRACK_DETAILS is dispatched when the api call succeeds', () => {
+    const dataObj = { 123456: { name: 'song1', trackId: 123456 } };
+    requestGetTrackDetailsGenerator = requestGetTrackDetails({ trackId });
+    requestGetTrackDetailsGenerator.next();
 
-  //   expect(requestGetTrackDetailsGenerator.next().done).toBeTruthy();
-  //   expect(requestGetTrackDetailsGenerator.next(apiResponseGenerator(true, data))).toEqual(
-  //     put({
-  //       type: trackContainerTypes.SUCCESS_GET_TRACK_DETAILS,
-  //       response: { data, dummyTrackDetailsObj }
-  //     })
-  //   );
-  // });
+    expect(requestGetTrackDetailsGenerator.next(dataObj).value).toEqual(
+      put({
+        type: trackContainerTypes.SUCCESS_GET_TRACK_DETAILS,
+        data: dataObj[trackId]
+      })
+    );
+  });
+
+  it('should ensure that the action FAILURE_GET_TRACK_DETAILS is dispatched when the api call fails', () => {
+    const dataObj = {};
+    requestGetTrackDetailsGenerator = requestGetTrackDetails({});
+    requestGetTrackDetailsGenerator.next();
+
+    expect(requestGetTrackDetailsGenerator.next(dataObj).value).toEqual(
+      put({
+        type: trackContainerTypes.FAILURE_GET_TRACK_DETAILS
+      })
+    );
+  });
 });

--- a/app/containers/TracksContainer/tests/saga.test.js
+++ b/app/containers/TracksContainer/tests/saga.test.js
@@ -4,29 +4,53 @@
 
 /* eslint-disable redux-saga/yield-effects */
 import { takeLatest, call, put } from 'redux-saga/effects';
-import { getSongs } from '@services/itunesApi';
-import { apiResponseGenerator } from '@utils/testUtils';
 import tracksContainerSaga, { requestGetTrackDetails, requestGetTracks } from '../saga';
 import { trackContainerTypes } from '../reducer';
+import { getSongs } from '@app/services/itunesApi';
+import { apiResponseGenerator } from '@app/utils/testUtils';
 
 describe('TracksContainer saga tests', () => {
   const generator = tracksContainerSaga();
-  const trackName = 'Arijit';
-  const trackId = 123456;
-  let requestSongsGenerator = requestGetTracks({ trackName });
-  let requestTrackIdGenerator = requestGetTrackDetails({ trackId });
+  let trackName = 'Arijit';
+  let requestGetTracksGenerator = null;
 
-  it('should start task to watch for REQUEST_GET_TRACKS action', () => {
+  it('should start task to watch for REQUEST_GET_TRACKS', () => {
     expect(generator.next().value).toEqual(takeLatest(trackContainerTypes.REQUEST_GET_TRACKS, requestGetTracks));
   });
 
-  it('should ensure that the action FAILURE_GET_TRACKS is dispatched when the api call fails', () => {
-    const res = requestSongsGenerator.next().value;
+  it('should start task to watch for SUCCESS_GET_TRACKS', () => {
+    requestGetTracksGenerator = requestGetTracks({ trackName });
+    const res = requestGetTracksGenerator.next().value;
     expect(res).toEqual(call(getSongs, trackName));
-    const errorResponse = {
-      errorMessage: 'There was an error while fetching requested information.'
+
+    const trackResponse = {
+      // eslint-disable-next-line prettier/prettier
+      results: [
+        { name: 'song1', trackId: 1 },
+        { name: 'song2', trackId: 2 }
+      ]
     };
-    expect(requestSongsGenerator.next(apiResponseGenerator(false, errorResponse)).value).toEqual(
+
+    const expectedRes = { 1: { name: 'song1', trackId: 1 }, 2: { name: 'song2', trackId: 2 } };
+    expect(requestGetTracksGenerator.next(apiResponseGenerator(true, trackResponse)).value).toEqual(
+      put({
+        type: trackContainerTypes.SUCCESS_GET_TRACKS,
+        data: expectedRes
+      })
+    );
+  });
+
+  it('should start task to watch for FAILURE_GET_TRACKS', () => {
+    trackName = 'Arijit';
+    requestGetTracksGenerator = requestGetTracks({ trackName });
+    const res = requestGetTracksGenerator.next().value;
+    expect(res).toEqual(call(getSongs, trackName));
+
+    const errorResponse = {
+      errorMessage: 'There is an error while fetching the tracks data'
+    };
+
+    expect(requestGetTracksGenerator.next(apiResponseGenerator(false, errorResponse)).value).toEqual(
       put({
         type: trackContainerTypes.FAILURE_GET_TRACKS,
         error: errorResponse
@@ -34,39 +58,9 @@ describe('TracksContainer saga tests', () => {
     );
   });
 
-  it('should ensure that the action SUCCESS_GET_TRACKS is dispatched when the api call succeeds', () => {
-    requestSongsGenerator = requestGetTracks({ trackName });
-    const res = requestSongsGenerator.next().value;
-    expect(res).toEqual(call(getSongs, trackName));
-    const sucessSongsResponse = {
-      resultCount: 0,
-      items: [{ songName: 'Naina', songArtist: 'Arijit Singh' }]
-    };
-    expect(requestSongsGenerator.next(apiResponseGenerator(true, sucessSongsResponse)).value).toEqual(
-      put({
-        type: trackContainerTypes.SUCCESS_GET_TRACKS,
-        data: sucessSongsResponse
-      })
-    );
-  });
-
   it('should start task to watch for REQUEST_GET_TRACK_DETAILS', () => {
     expect(generator.next().value).toEqual(
       takeLatest(trackContainerTypes.REQUEST_GET_TRACK_DETAILS, requestGetTrackDetails)
-    );
-  });
-
-  it('should ensure that the action SUCCESS_GET_TRACK_DETAILS is dispatched when the api call succeeds', () => {
-    requestTrackIdGenerator = requestGetTrackDetails({ trackId });
-    requestTrackIdGenerator.next().value;
-    const succcessTrackIdResponse = {
-      results: [{ trackId }]
-    };
-    expect(requestTrackIdGenerator.next(apiResponseGenerator(true, succcessTrackIdResponse)).value).toEqual(
-      put({
-        type: trackContainerTypes.SUCCESS_GET_TRACK_DETAILS,
-        data: { trackId }
-      })
     );
   });
 });

--- a/app/containers/TracksContainer/tests/saga.test.js
+++ b/app/containers/TracksContainer/tests/saga.test.js
@@ -63,4 +63,22 @@ describe('TracksContainer saga tests', () => {
       takeLatest(trackContainerTypes.REQUEST_GET_TRACK_DETAILS, requestGetTrackDetails)
     );
   });
+
+  // it('should ensure that the action SUCCESS_GET_TRACK_DETAILS is dispatched when the api call succeeds', () => {
+  //   requestGetTrackDetailsGenerator = requestGetTrackDetails({ trackId });
+  //   const dataObj = { 18556408: { name: 'song1', trackId: 18556408 } };
+  //   requestGetTrackDetailsGenerator.next(dataObj).value;
+  //   requestGetTrackDetailsGenerator.next(dataObj).value;
+  //   const data = { results: [{ trackId }] };
+  //   const dummyTrackDetailsObj = { name: 'song1', trackId: 18556408 };
+  //   console.log(requestGetTrackDetailsGenerator.next().value);
+
+  //   expect(requestGetTrackDetailsGenerator.next().done).toBeTruthy();
+  //   expect(requestGetTrackDetailsGenerator.next(apiResponseGenerator(true, data))).toEqual(
+  //     put({
+  //       type: trackContainerTypes.SUCCESS_GET_TRACK_DETAILS,
+  //       response: { data, dummyTrackDetailsObj }
+  //     })
+  //   );
+  // });
 });

--- a/app/containers/TracksContainer/tests/selectors.test.js
+++ b/app/containers/TracksContainer/tests/selectors.test.js
@@ -5,7 +5,9 @@ import {
   selectTrackDetailsError,
   selectTrackId,
   selectTracksData,
-  selectTracksError
+  selectTracksError,
+  selectSingleTrackLoading,
+  selectTracksContainerDomain
 } from '../selectors';
 
 describe('TracksContainer selector tests', () => {
@@ -16,6 +18,7 @@ describe('TracksContainer selector tests', () => {
   let trackId;
   let tracksError;
   let trackDetailsError;
+  let singleTrackLoading;
 
   beforeEach(() => {
     (trackName = 'Naina'), (tracksData = { songName: 'Naina', songArtist: 'Arijit Singh' });
@@ -24,6 +27,7 @@ describe('TracksContainer selector tests', () => {
     trackDetails = [{ trackId }];
     tracksError = 'something went wrong';
     trackDetailsError = 'error while fetching the track details';
+    singleTrackLoading = false;
 
     mockedState = {
       tracksContainer: {
@@ -32,14 +36,21 @@ describe('TracksContainer selector tests', () => {
         trackDetails,
         tracksError,
         trackDetailsError,
-        trackId
+        trackId,
+        singleTrackLoading
       }
     };
   });
 
+  it('should check for initial state when state  will be null', () => {
+    const { initialState } = require('../reducer');
+    mockedState = {};
+    expect(selectTracksContainerDomain(mockedState)).toBe(initialState);
+  });
+
   it('should select the trackName', () => {
     const trackNameSelector = selectTrackName();
-    expect(trackNameSelector(mockedState)).toEqual(trackName);
+    expect(trackNameSelector(mockedState)).toStrictEqual(trackName);
   });
 
   it('should select the tracksContainer state', () => {
@@ -48,8 +59,8 @@ describe('TracksContainer selector tests', () => {
   });
 
   it('should select tracksData', () => {
-    const searchsingleTrackDataSelector = selectTracksData();
-    expect(searchsingleTrackDataSelector(mockedState)).toEqual(tracksData);
+    const searchSingleTrackDataSelector = selectTracksData();
+    expect(searchSingleTrackDataSelector(mockedState)).toEqual(tracksData);
   });
 
   it('should select the trackDetails', () => {
@@ -65,6 +76,11 @@ describe('TracksContainer selector tests', () => {
   it('should select the trackDetailsError', () => {
     const trackErrorSelector = selectTrackDetailsError();
     expect(trackErrorSelector(mockedState)).toEqual(trackDetailsError);
+  });
+
+  it('should select the selectSingleTrackLoading', () => {
+    const trackDetailsLoadingSelector = selectSingleTrackLoading();
+    expect(trackDetailsLoadingSelector(mockedState)).toEqual(singleTrackLoading);
   });
 
   it('should select the trackError', () => {

--- a/app/services/itunesApi.js
+++ b/app/services/itunesApi.js
@@ -4,5 +4,3 @@ const itunesApi = generateApiClient('itunes');
 export const getSongs = trackName => {
   return itunesApi.get(`/search?term=${trackName}`);
 };
-
-export const getTrackDetails = trackId => itunesApi.get(`/lookup?id=${trackId}`);

--- a/app/services/itunesApi.js
+++ b/app/services/itunesApi.js
@@ -1,4 +1,8 @@
 import { generateApiClient } from '@utils/apiUtils';
 const itunesApi = generateApiClient('itunes');
 
-export const getSongs = trackName => itunesApi.get(`/search?term=${trackName}`);
+export const getSongs = trackName => {
+  return itunesApi.get(`/search?term=${trackName}`);
+};
+
+export const getTrackDetails = trackId => itunesApi.get(`/lookup?id=${trackId}`);

--- a/app/themes/tests/fonts.test.js
+++ b/app/themes/tests/fonts.test.js
@@ -4,7 +4,9 @@ import media from '../media';
 
 describe('fonts', () => {
   it('should have the correct font-size', () => {
+    expect(fonts.size.medium()).toEqual(expect.arrayContaining([expect.stringContaining('font-size:1rem')]));
     expect(fonts.size.small()).toEqual(expect.arrayContaining([expect.stringContaining('font-size:0.875rem')]));
+    expect(fonts.size.xSmall()).toEqual(expect.arrayContaining([expect.stringContaining('font-size:0.75rem')]));
     expect(fonts.size.regular()).toEqual(expect.arrayContaining([expect.stringContaining('font-size:1rem;')]));
     expect(fonts.size.big()).toEqual(expect.arrayContaining([expect.stringContaining('font-size:1.25rem;')]));
     expect(fonts.size.large()).toEqual(expect.arrayContaining([expect.stringContaining('font-size:1.5rem;')]));
@@ -14,6 +16,7 @@ describe('fonts', () => {
     expect(fonts.weights.light()).toEqual(expect.arrayContaining(['font-weight:400;']));
     expect(fonts.weights.bold()).toEqual(expect.arrayContaining(['font-weight:600;']));
     expect(fonts.weights.normal()).toEqual(expect.arrayContaining(['font-weight:500;']));
+    expect(fonts.weights.xBold()).toEqual(expect.arrayContaining(['font-weight:700;']));
   });
   it('should have the correct font-weight and font-size', () => {
     expect(fonts.style.heading()).toEqual(expect.arrayContaining(['font-size:1.5rem;', ' ', 'font-weight:600;']));


### PR DESCRIPTION
### Ticket Link

### Description

- Optimised the tracks data when a user clicks on show details of a component 
( it would not render the entire tracks data, only render the track details of a specific track component )

### Steps to Reproduce / Test

---

---

### Checklist

- [ ] PR description included
- [ ] `yarn test` passes
- [ ] Tests are [changed or added]
- [ ] Relevant documentation is changed or added (and PR referenced)

### GIF's

![1](https://user-images.githubusercontent.com/114564643/195773067-1fbc5e9d-5d34-4dce-ab0d-12a2a8404edf.gif)

### Live Link

---

- http://wednesday-react-template.s3-website.ap-south-1.amazonaws.com/<BRANCH_NAME>
